### PR TITLE
Update download.py

### DIFF
--- a/download.py
+++ b/download.py
@@ -30,7 +30,7 @@ async def download_resource(resource_dir: Path, name: str, _type: Optional[str] 
         Try to download resources, including fonts, fortune copywriting, but not images.
         For fonts & copywriting, download and save into files when missing. Otherwise, raise ResourceError
     '''
-    base_url: str = "https://raw.fastgit.org/MinatoAquaCrews/nonebot_plugin_fortune/beta/nonebot_plugin_fortune/resource"
+    base_url: str = "https://raw.fgit.ml/MinatoAquaCrews/nonebot_plugin_fortune/master/nonebot_plugin_fortune/resource"
     
     if isinstance(_type, str):
         url: str = base_url + "/" + _type + "/" + name


### PR DESCRIPTION
原来的资源地址已经失效，使用原来的地址会导致 Hoshino 无法正常启动，根据上游项目的更新，更换为新的地址
```
[2023-12-11 14:49:43,163 nonebot] WARNING: Error occurred when downloading https://raw.fastgit.org/MinatoAquaCrews/nonebot_plugin_fortune/beta/nonebot_plugin_fortune/resource/fortune/copywriting.json, retry: 1/3
[2023-12-11 14:50:03,175 nonebot] WARNING: Error occurred when downloading https://raw.fastgit.org/MinatoAquaCrews/nonebot_plugin_fortune/beta/nonebot_plugin_fortune/resource/fortune/copywriting.json, retry: 2/3
```